### PR TITLE
Fix headers error in RestUtilities request method

### DIFF
--- a/client-react/services/RestUtilities.ts
+++ b/client-react/services/RestUtilities.ts
@@ -35,17 +35,17 @@ export default class RestUtilities {
         let isJsonResponse: boolean = false;
         let isBadRequest = false;
         let body = data;
-        let headers: { [key: string]: string } = {
-            'Authorization': `Bearer ${AuthStore.getToken()}`,
-            'Accept': 'application/json'
-        };
+        let headers = new Headers();
+
+        headers.set('Authorization',`Bearer ${AuthStore.getToken()}`);
+        headers.set('Accept','application/json');
 
         if (data) {
             if ((typeof data === 'object')) {
-                headers['Content-Type'] = 'application/json';
+                headers.set('Content-Type','application/json');
                 body = JSON.stringify(data);
             } else {
-                headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                headers.set('Content-Type','application/x-www-form-urlencoded');
             }
         }
 


### PR DESCRIPTION
When running the app I encountered the following error:

ERROR in ../client-react/services/RestUtilities.ts
(58,27): error TS2345: Argument of type '{ method: string; headers: { [key: string]: string; }; body: string | Object; }' is not assignable to parameter of type 'RequestInit'.
  Types of property 'headers' are incompatible.
    Type '{ [key: string]: string; }' is not assignable to type 'Headers | string[][]'.
      Type '{ [key: string]: string; }' is not assignable to type 'string[][]'.
        Property 'find' is missing in type '{ [key: string]: string; }'.
ERROR in ../client-react/services/RestUtilities.ts
(62,18): error TS7006: Parameter 'response' implicitly has an 'any' type.

I added a fix.

My current OS is Ubuntu 17.10. When I used Windows I did not have this issue.
