### PR TITLE
Updates for Windows environment, added support for Visual Studio operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ ops/*.retry
 
 # IDE
 .idea/
+.vs/

--- a/api/Properties/launchSettings.json
+++ b/api/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:5000/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "api": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:5000/"
+    }
+  }
+}

--- a/api/Properties/launchSettings.json
+++ b/api/Properties/launchSettings.json
@@ -11,7 +11,9 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "http://localhost:5000",
       "environmentVariables": {
+        "NODE_PATH": "../node_modules/",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
@@ -19,6 +21,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
+		"NODE_PATH": "../node_modules/",
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "http://localhost:5000/"

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -24,38 +24,4 @@
   </ItemGroup>
   
   
-  <Target Name="DebugRunWebpack" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' ">
-	<Message Importance="high" Text="Installing any non-peer missing dependencies.." />
-    <Exec Command="npm install" />
-	
-	<!-- It would seem, that the npm install cmd targets the parent directory(natural path of the routine), and yet, the node webpack execution does not. So we go up one level  -->
-    <Message Importance="high" Text="Performing first-run Webpack build..." />
-    <Exec Command="node ../node_modules/webpack/bin/webpack.js --config ../client-react/webpack.config.js" />
-	
-	<Message Importance="high" Text="Starting up docker instances (if not started).." />
-	<Exec Command="docker-compose up -d" />
-  </Target>
-  
-  <Target Name="RunWebpack" AfterTargets="ComputeFilesToPublish">
-    <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-    <Exec Command="npm install" />
-    <Exec Command="node ../node_modules/webpack/bin/webpack.js --config ../client-react/webpack.config.js --env.prod" />
-
-    <!-- Include the newly-built files in the publish output -->
-    <ItemGroup>
-      <DistFiles Include="wwwroot\*.js;" />
-      <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
-        <RelativePath>%(DistFiles.Identity)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </ResolvedFileToPublish>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(Configuration)'=='Debug'">
-      <NpmFiles Include="..\node_modules\**;..\package.json;..\client-react\webpack.config.js;..\client-react\tsconfig.json;..\postcss.config.js;..\.babelrc" />
-      <ResolvedFileToPublish Include="@(NpmFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
-        <RelativePath>%(NpmFiles.Identity)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </ResolvedFileToPublish>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -22,4 +22,40 @@
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
   </ItemGroup>
+  
+  
+  <Target Name="DebugRunWebpack" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' ">
+	<Message Importance="high" Text="Installing any non-peer missing dependencies.." />
+    <Exec Command="npm install" />
+	
+	<!-- It would seem, that the npm install cmd targets the parent directory(natural path of the routine), and yet, the node webpack execution does not. So we go up one level  -->
+    <Message Importance="high" Text="Performing first-run Webpack build..." />
+    <Exec Command="node ../node_modules/webpack/bin/webpack.js --config ../client-react/webpack.config.js" />
+	
+	<Message Importance="high" Text="Starting up docker instances (if not started).." />
+	<Exec Command="docker-compose up -d" />
+  </Target>
+  
+  <Target Name="RunWebpack" AfterTargets="ComputeFilesToPublish">
+    <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
+    <Exec Command="npm install" />
+    <Exec Command="node ../node_modules/webpack/bin/webpack.js --config ../client-react/webpack.config.js --env.prod" />
+
+    <!-- Include the newly-built files in the publish output -->
+    <ItemGroup>
+      <DistFiles Include="wwwroot\*.js;" />
+      <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
+        <RelativePath>%(DistFiles.Identity)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)'=='Debug'">
+      <NpmFiles Include="..\node_modules\**;..\package.json;..\client-react\webpack.config.js;..\client-react\tsconfig.json;..\postcss.config.js;..\.babelrc" />
+      <ResolvedFileToPublish Include="@(NpmFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
+        <RelativePath>%(NpmFiles.Identity)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
gitignore needs to exclude internal visual studio runtime files (sqlite).
Also requires a Debug instance (in IDE) launch file (auto-generated; modified to correct port and auto-browser launch).
Finally, the webpack directory is non-standard according to assumed structure by Visual Studio.
So added Webpack compilation profiles (hidden from visual studio IDE project settings) which target the correct webpack folder and files (as used when clicking [Debug] or [Publish] ops).

Note:  Have not tested this change (.csproj file) under VS Code IDE. I would presume it would remain unaffected. Recommend pull & test on that platform, prior to considering a direct merge on master. 

Works great on Windows & Visual Studio 2017. 
Hope this finds you well, and good day.